### PR TITLE
Add `--skip-local-symbols` CLI flag to skip local symbol extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A CLI tool to extract dylib from dyld_shared_cache
 ```sh
 OVERVIEW: Extract dylib from dyld shared cache
 
-USAGE: dyld-shared-cache-extractor <input-path> [--output <output>] [--dylib <dylib>] [--all]
+USAGE: dyld-shared-cache-extractor <input-path> [--output <output>] [--dylib <dylib>] [--all] [--skip-local-symbols]
 
 ARGUMENTS:
   <input-path>            Path to the input main dyld shared cache file.
@@ -26,6 +26,8 @@ OPTIONS:
                           (default: ./)
   -d, --dylib <dylib>     Name of dylib to be extracted.
   --all                   Extract all dylibs.
+  --skip-local-symbols    Skip extraction of local symbols from dyld local
+                          symbol cache.
   --version               Show the version.
   -h, --help              Show help information.
 ```

--- a/Sources/LinkeditOptimizer.swift
+++ b/Sources/LinkeditOptimizer.swift
@@ -46,6 +46,7 @@ final class LinkeditOptimizer {
 
     let machO: MachOFile
     let cache: FullDyldCache
+    let skipLocalSymbols: Bool
 
     private(set) var linkedit: Segment?
     private(set) var symtab: LoadCommandInfo<symtab_command>?
@@ -60,10 +61,12 @@ final class LinkeditOptimizer {
 
     init(
         machO: MachOFile,
-        cache: FullDyldCache
+        cache: FullDyldCache,
+        skipLocalSymbols: Bool = false
     ) {
         self.machO = machO
         self.cache = cache
+        self.skipLocalSymbols = skipLocalSymbols
     }
 }
 
@@ -278,21 +281,23 @@ extension LinkeditOptimizer {
 
         // local symbols
         var localSymbols: [MachOFile.Symbol] = []
-        if let symbolsCache = try? cache.symbolCache,
-           let info = symbolsCache.localSymbolsInfo,
-           // On new caches, the dylibOffset is 64-bits, and is a VM offset
-           let entry = info.entry64(for: machO, in: symbolsCache) {
-            if let symbols64 = info.symbols64(in: symbolsCache) {
-                localSymbols = Array(symbols64[entry.nlistRange])
-            } else if let symbols32 = info.symbols32(in: symbolsCache) {
-                localSymbols = Array(symbols32[entry.nlistRange])
-            }
-        } else if let info = cache.localSymbolsInfo,
-           let entry = info.entry(for: machO, in: cache) {
-            if let symbols64 = info.symbols64(in: cache) {
-                localSymbols = Array(symbols64[entry.nlistRange])
-            } else if let symbols32 = info.symbols32(in: cache) {
-                localSymbols = Array(symbols32[entry.nlistRange])
+        if !skipLocalSymbols {
+            if let symbolsCache = try? cache.symbolCache,
+               let info = symbolsCache.localSymbolsInfo,
+               // On new caches, the dylibOffset is 64-bits, and is a VM offset
+               let entry = info.entry64(for: machO, in: symbolsCache) {
+                if let symbols64 = info.symbols64(in: symbolsCache) {
+                    localSymbols = Array(symbols64[entry.nlistRange])
+                } else if let symbols32 = info.symbols32(in: symbolsCache) {
+                    localSymbols = Array(symbols32[entry.nlistRange])
+                }
+            } else if let info = cache.localSymbolsInfo,
+                      let entry = info.entry(for: machO, in: cache) {
+                if let symbols64 = info.symbols64(in: cache) {
+                    localSymbols = Array(symbols64[entry.nlistRange])
+                } else if let symbols32 = info.symbols32(in: cache) {
+                    localSymbols = Array(symbols32[entry.nlistRange])
+                }
             }
         }
 

--- a/Sources/SharedCacheDylibExtractor.swift
+++ b/Sources/SharedCacheDylibExtractor.swift
@@ -14,11 +14,16 @@ final class SharedCacheDylibExtractor {
     typealias FileHandle = MemoryMappedFile
 
     let outputDirectory: URL
+    let skipLocalSymbols: Bool
 
     private let fileManager = FileManager.default
 
-    init(outputDirectory: URL) {
+    init(
+        outputDirectory: URL,
+        skipLocalSymbols: Bool = false
+    ) {
         self.outputDirectory = outputDirectory
+        self.skipLocalSymbols = skipLocalSymbols
     }
 
     func extract(for machO: MachOFile, in cache: FullDyldCache) throws {
@@ -79,7 +84,8 @@ extension SharedCacheDylibExtractor {
         // optimize linkedit
         let linkeditOptimizer = LinkeditOptimizer(
             machO: machO,
-            cache: cache
+            cache: cache,
+            skipLocalSymbols: skipLocalSymbols
         )
         try linkeditOptimizer.optimizeLoadCommands(
             writeHandle: writeHandle

--- a/Sources/dyld_shared_cache_extractor.swift
+++ b/Sources/dyld_shared_cache_extractor.swift
@@ -33,6 +33,12 @@ struct dyld_shared_cache_extractor: ParsableCommand {
     @Flag(name: .long, help: "Extract all dylibs.")
     var all: Bool = false
 
+    @Flag(
+        name: .long,
+        help: "Skip extraction of local symbols from dyld local symbol cache."
+    )
+    var skipLocalSymbols: Bool = false
+
     var inputURL: URL { .init(fileURLWithPath: inputPath) }
     var outputDirectoryURL: URL {
         if let output {
@@ -121,7 +127,8 @@ extension dyld_shared_cache_extractor {
         outputDirectory: URL
     ) throws {
         let extractor = SharedCacheDylibExtractor(
-            outputDirectory: outputDirectory
+            outputDirectory: outputDirectory,
+            skipLocalSymbols: skipLocalSymbols
         )
         try extractor.extract(for: machO, in: cache)
     }


### PR DESCRIPTION
closes #2

### Motivation
- Provide an option to skip extracting local symbols from the dyld local symbol cache to speed up extraction or avoid relying on a separate symbol cache.
- Make skipping local-symbol processing configurable per-run so the behavior is explicit and threadable through the extractor stack.

### Description
- Add a new CLI flag `--skip-local-symbols` to `dyld_shared_cache_extractor` and include it in the usage text in `README.md`.
- Thread the option into `SharedCacheDylibExtractor` by adding a `skipLocalSymbols` property and constructor parameter and passing it from the CLI.
- Add a `skipLocalSymbols` property to `LinkeditOptimizer` and guard the local-symbol loading logic so local symbols are not read when the flag is enabled.

### Testing
- Attempted to build with `swift build`, but the build failed in this environment due to inability to fetch SwiftPM dependencies (`CONNECT tunnel failed, response 403`), so a full build could not be completed.
- No automated unit tests were run in this environment.
